### PR TITLE
Added option to blacklist users in config.json

### DIFF
--- a/phovea_security_store_ldap/config.json
+++ b/phovea_security_store_ldap/config.json
@@ -7,6 +7,9 @@
     }
   ],
 
+  /*lowercase usernames which are denied access*/
+  "blacklist": [],
+
   /*server settings*/
   "hostname": "",
   "port": 389,

--- a/phovea_security_store_ldap/ldap.py
+++ b/phovea_security_store_ldap/ldap.py
@@ -127,6 +127,11 @@ class LDAPStore(object):
     return self.login(parts[0], dict(password=parts[1]))
 
   def login(self, username, extra_fields=None):
+    # Check if user is blacklisted
+    if username and username.lower() in self._config.get('blacklist', default=[]):
+      log.info(f'unsuccessful login for blacklisted user {username}')
+      return None
+
     if extra_fields is None:
       extra_fields = {}
     password = extra_fields['password']


### PR DESCRIPTION
To deny access to specific users, simply add the `phovea_security_store_ldap.blacklist` option, which is an array of lowercase usernames which will not be able to login. 